### PR TITLE
feat: move action to root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-
   - package-ecosystem: github-actions
-    directory: /.github/actions/poetry-install
+    directory: /
     schedule:
-      interval: 'weekly'
-    groups:
-      actions:
-        patterns:
-        - "actions/*"
+      interval: weekly

--- a/README.md
+++ b/README.md
@@ -1,54 +1,53 @@
-# Python - Poetry install
+# Python - Poetry install GitHub Action
 
-- This pipeline is designed to install the dependencies of a Python project that uses Poetry.
-It will install the dependencies and cache them for future runs.
-- The pipeline is designed to be as generic as possible, so they can be easily reused in any project.
-- This repository is a part of the generic GitHub Actions pipeline collection that can be used in any project.
+This repository provides a reusable GitHub Action for setting up Python and Poetry and installing and caching your project's Poetry dependencies.
 
 ## Usage
 
-Here is a basic example on how you can integrate it in your project.
-
-<details>
-  <summary>Example workflow</summary>
-
-This workflow is executed automatically on push to the main branch, on a pull request and can also be executed manually from the actions tab `workflow_dispatch`.
-
-In the code below you need to replace `<python_version>` with the Python version you want to use. For example `3.11` or `3.9`.
+To use the action, add it to a workflow in your repository:
 
 ```yml
 name: Build Python project
 
 on:
-  workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - main
+    workflow_dispatch:
+    pull_request:
+    push:
+        branches:
+            - main
 
 jobs:
-  build-python:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    build-python:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      # Using the action
-      - name: Install dependencies
-        uses: minvws/action-python-poetry-install/.github/actions/poetry-install@main
-        with:
-          python_version: <python_version>
+            - name: Install Python and dependencies
+              uses: minvws/action-python-poetry-install@v1
+              with:
+                  python_version: <python_version>
 ```
 
-</details>
+Replace `<python_version>` with the Python version your project needs.
+
+In this basic example, the workflow is executed automatically on push to the `main` branch and on any pull request. And thanks to the `workflow_dispatch` trigger it can also be executed manually from the repository's Actions tab.
 
 ### Configuration
 
-The action has inputs. The inputs are:
+The action has the following inputs:
 
-- python_version: Semver version of the Python version you want to use. For example `3.11` or `3.9`.
+- `python_version`: which version of Python to use. For example `"3.11"` or `">=3.9 <3.14"`.
 
 ## Contributing
 
 If you want to contribute a new pipeline, please check the reusable workflow guidelines in the
 [GitHub documentation](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow).
+
+## License
+
+This repository is released under the EUPL 1.2 license. See [LICENSE](./LICENSE) for details.
+
+## Part of iCore
+
+This package is part of the iCore project.

--- a/action.yml
+++ b/action.yml
@@ -10,13 +10,14 @@ runs:
   steps:
     - name: Update PATH
       shell: bash
-      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-    - name: Install poetry
+    - name: Install Poetry
       shell: bash
-      run: pip3 install poetry
+      run: pipx install poetry
 
-    - uses: actions/setup-python@v5
+    - name: Setup Python
+      uses: actions/setup-python@v5
       with:
         python-version: "${{ inputs.python_version }}"
         cache: poetry


### PR DESCRIPTION
Move the action to the root and update the docs accordingly, instructing users to use `minvws/action-python-poetry-install@v1` instead of `minvws/action-python-poetry-install/.github/actions/poetry-install@main`.
